### PR TITLE
[v1] COVID-19 Tracker release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ It is built using web components with the help from [LitElement](https://lit-ele
 For the data source, it uses the free [COVID-19 API](https://api-sports.io/documentation/covid-19) by [api-sports](https://rapidapi.com/user/api-sports) from [RapidAPI](https://rapidapi.com/).
 
 ## Main features
-- **Country search**: user can search a country via its *name*.
+- **Country search**: user can search a country via its **name**.
 - **Coverage filtering**: user can filter the coverage of the list, either **worldwide** or by **continent**. Total count per coverage is also displayed.
 - **Case count sorting**: user can sort the list via [case count category](#case-count-category) in **ascending** or **descending** (*default*) order.
 - **Country pinning**: users can pin a country that would **stay on top of the list**. It is saved via `localStorage`.
-  - **User location**: gets the user's country for default country pinned.
 
 ## Other features
 - **Dark mode**: the app's theme adapts to the device/browser's current theme.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is a redesigned spin-off of once was the practice app for my current employ
 
 If you'll check the [initial commits](https://github.com/jjdcabasolo/covid-19-tracker-app/commit/f7705c4e68920899f2f0752c74a8840fe7756c12), there are a lot of initial files. The from-scratch commits can be found on a private repo.
 
-I asked permission to my boss if I can get that app and use it on my personal portfolio. And it was granted. Yay 🥳🎉
+I asked permission to my boss if I can use that app and put it on my personal portfolio. And it was granted. Yay 🥳🎉
 
 > [This is the original app](http://app-tracker-jourish.herokuapp.com/), the ones I used on our final presentation.
 
@@ -52,7 +52,7 @@ npm run start
 # Acknowledgements
 
 I want to thank you the following persons for being a part of the development of this app 😍🥰
-- **Boss Mikko, et. al**, for letting me use this app for my personal portfolio and the code review comments during the initial app development
-- **Kharisa**, **Blessy**, and **RC**, for acting as my user interface consultants, as well as providing the initial comments and suggestions interface-wise
-- **Jemil** and **Camille**, for testing the app, as well as providing suggestions for improvement
+- **Boss Mikko, Boss Niko, and Sammy**, for all the help, including lit-element basics, app structure, and code review during the initial app development
+- **Kharisa** and **RC**, for acting as my design consultants, as well as providing the initial comments and suggestions interface-wise
+- **Jemil**, **Camille**, and **Blessy** for testing the app, as well as providing suggestions for improvement
 - and you, for taking the time to read this long README.md 🤣

--- a/src/components/country-list-connected.js
+++ b/src/components/country-list-connected.js
@@ -4,7 +4,7 @@ import { formatCountryName, getCountryCode } from '../utils/country';
 
 import continents from '../constants/continents';
 
-import { apiHost, apiKey, apiUrl, apiPassphrase } from '../constants/api';
+import { apiHost, apiKey, apiPassphrase, apiUrl } from '../constants/api';
 
 export default class CountryListConnected extends CountryList {
   async fetchCountries() {
@@ -142,29 +142,6 @@ export default class CountryListConnected extends CountryList {
 
     if (userPref) {
       this.preference = [...this.preference, ...userPref.split(',')];
-      return;
-    }
-
-    try {
-      const response = await fetch('https://freegeoip.app/json/', {
-        method: 'GET',
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-        },
-      });
-
-      if (response.status !== 200) throw response;
-
-      const toJSON = await response.json();
-      const country = toJSON.country_name.toLowerCase();
-      const code = getCountryCode(country);
-
-      localStorage.setItem('preference', code);
-      this.preference = [...this.preference, code];
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.log(e);
     }
   }
 }

--- a/src/components/country-search-form.js
+++ b/src/components/country-search-form.js
@@ -28,15 +28,21 @@ export default class CountrySearchForm extends LitElement {
         }
         .clear-icon,
         .search-icon {
-          position: absolute;
+          -khtml-user-select: none;
+          -moz-user-select: none;
+          -ms-user-select: none;
+          -webkit-touch-callout: none;
+          -webkit-user-select: none;
           cursor: pointer;
+          cursor: pointer;
+          position: absolute;
+          user-select: none;
+          bottom: 14px;
         }
         .search-icon {
-          bottom: 13px;
           left: 8px;
         }
         .clear-icon {
-          bottom: 14px;
           right: 8px;
         }
         .disabled {
@@ -132,12 +138,15 @@ export default class CountrySearchForm extends LitElement {
   handleClear() {
     const input = this.shadowRoot.getElementById('countrySearch');
 
-    input.value = '';
-    this.dispatchEvent(
-      new CustomEvent('handle-search-query', {
-        detail: { query: '' },
-      })
-    );
+    if (input.value.length > 0) {
+      input.value = '';
+
+      this.dispatchEvent(
+        new CustomEvent('handle-search-query', {
+          detail: { query: '' },
+        })
+      );
+    }
   }
 }
 

--- a/src/components/country-search-form.js
+++ b/src/components/country-search-form.js
@@ -30,12 +30,13 @@ export default class CountrySearchForm extends LitElement {
         .search-icon {
           position: absolute;
           cursor: pointer;
-          bottom: 13px;
         }
         .search-icon {
+          bottom: 13px;
           left: 8px;
         }
         .clear-icon {
+          bottom: 14px;
           right: 8px;
         }
         .disabled {
@@ -52,12 +53,13 @@ export default class CountrySearchForm extends LitElement {
           .clear-icon,
           .search-icon {
             --mdc-icon-size: 20px;
-            bottom: 24px;
           }
           .search-icon {
+            bottom: 24px;
             left: 12px;
           }
           .clear-icon {
+            bottom: 25px;
             right: 12px;
           }
         }

--- a/src/components/icon-button.js
+++ b/src/components/icon-button.js
@@ -16,11 +16,11 @@ export default class IconButton extends LitElement {
         }
         .icon {
           color: var(--light-theme-secondary-color);
-          --mdc-icon-size: 24px;
+          --mdc-icon-size: 20px;
         }
         @media screen and (max-width: 600px) {
           .icon {
-            --mdc-icon-size: 28px;
+            --mdc-icon-size: 24px;
           }
         }
         :host([inactive]) .icon-container .icon {

--- a/src/components/utility-panel.js
+++ b/src/components/utility-panel.js
@@ -367,9 +367,9 @@ export default class UtilityPanel extends LitElement {
     return html`
       <div class="small-text primary-text">
         Data may not be 100% accurate.
-        <span class="secondary-text"
-          >It's a free API, so please bear with the API provider 😅</span
-        >
+        <span class="secondary-text">
+          It's a free API, so please bear with the API provider 😅
+        </span>
       </div>
     `;
   }
@@ -387,6 +387,8 @@ export default class UtilityPanel extends LitElement {
   handleSearchQuery({ detail }) {
     if (this.isMobile) {
       window.scrollTo({ top: 0, behavior: 'smooth' });
+      document.body.style.overflow = '';
+      this.open = false;
     }
 
     this.dispatchEvent(new CustomEvent('handle-search-query', { detail }));


### PR DESCRIPTION
# covid-19-tracker-app

[![Built with open-wc recommendations](https://img.shields.io/badge/built%20with-open--wc-blue.svg)](https://github.com/open-wc) [![A progressive web app](https://img.shields.io/badge/-progressive%20web%20%20app-orange)](https://web.dev/progressive-web-apps/)

**COVID-19 Tracker** is a web application that lists ***COVID-19 case count of countries*** around the world.

## DEMO: [Click here to view the demo!](https://jjdcabasolo.github.io/covid-19-tracker-app)

## Case count category
The case count is categorized into three:
1. **Confirmed cases**: includes all types of reported cases, as well as recoveries.
2. **Deaths**: a separate count for all deaths caused by COVID-19
3. **Recoveries**: a subset of the confirmed cases count, presents the number of discharges/patient recoveries

## Tech stack
It is built using web components with the help from [LitElement](https://lit-element.polymer-project.org/). The project was scaffolded using [open-wc](https://open-wc.org/)'s CLI.

For the data source, it uses the free [COVID-19 API](https://api-sports.io/documentation/covid-19) by [api-sports](https://rapidapi.com/user/api-sports) from [RapidAPI](https://rapidapi.com/).

## Main features
- **Country search**: user can search a country via its **name**.
- **Coverage filtering**: user can filter the coverage of the list, either **worldwide** or by **continent**. Total count per coverage is also displayed.
- **Case count sorting**: user can sort the list via [case count category](#case-count-category) in **ascending** or **descending** (*default*) order.
- **Country pinning**: users can pin a country that would **stay on top of the list**.

## Other features
- **Dark mode**: the app's theme adapts to the device/browser's current theme.
- **PWA**: this is a progressive web app, it can be installed on supported devices and can work offline.
> For offline, the data for the last online session would be used.

